### PR TITLE
Bugfix types for fs.makedirectoryoptions.mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.0.0 YYYY-mm-dd
+
+- Correct typings for updates @types/node.
+
 ## v2.1.4 2019-10-08
 
 - Bugfix `mocha-steps` wrapper for testing.

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@types/chai": "^4.2.3",
     "@types/dirty-chai": "^2.0.2",
     "@types/mocha": "^5.2.7",
-    "@types/node": "^12.7.11",
+    "@types/node": "^12.12.62",
     "chai": "^4.2.0",
     "changelog-parser": "^2.8.0",
     "coveralls": "^3.0.6",

--- a/test/fs-blob-storage-errors.ts
+++ b/test/fs-blob-storage-errors.ts
@@ -39,9 +39,7 @@ Feature("Test FsBlobStorage errors", () => {
     })
 
     Then("error is caught", () => {
-      expect(error)
-        .to.be.an("error")
-        .and.have.property("code", "ENOENT")
+      expect(error).to.be.an("error").and.have.property("code", "ENOENT")
     })
   })
 
@@ -68,9 +66,7 @@ Feature("Test FsBlobStorage errors", () => {
     })
 
     Then("error is caught", () => {
-      expect(error)
-        .to.be.an("error")
-        .and.have.property("code", "ENOENT")
+      expect(error).to.be.an("error").and.have.property("code", "ENOENT")
     })
   })
 
@@ -97,9 +93,7 @@ Feature("Test FsBlobStorage errors", () => {
     })
 
     Then("error is caught", () => {
-      expect(error)
-        .to.be.an("error")
-        .and.have.property("code", "ENOENT")
+      expect(error).to.be.an("error").and.have.property("code", "ENOENT")
     })
   })
 
@@ -126,9 +120,7 @@ Feature("Test FsBlobStorage errors", () => {
     })
 
     Then("error is caught", () => {
-      expect(error)
-        .to.be.an("error")
-        .and.have.property("code", "ENOENT")
+      expect(error).to.be.an("error").and.have.property("code", "ENOENT")
     })
   })
 })

--- a/test/fs-blob-storage-exclusive-errors.ts
+++ b/test/fs-blob-storage-exclusive-errors.ts
@@ -43,9 +43,7 @@ Feature("Test FsBlobStorage errors for exclusive option", () => {
     })
 
     Then("error is caught", () => {
-      expect(error)
-        .to.be.an("error")
-        .and.have.property("code", "EEXIST")
+      expect(error).to.be.an("error").and.have.property("code", "EEXIST")
     })
   })
 
@@ -76,9 +74,7 @@ Feature("Test FsBlobStorage errors for exclusive option", () => {
     })
 
     Then("error is caught", () => {
-      expect(error)
-        .to.be.an("error")
-        .and.have.property("code", "EEXIST")
+      expect(error).to.be.an("error").and.have.property("code", "EEXIST")
     })
   })
 })

--- a/test/lib/mock-fs.ts
+++ b/test/lib/mock-fs.ts
@@ -146,7 +146,11 @@ export function mkdir(
     callback = options
   } else if (typeof options === "object") {
     const makeDirectoryOptions = options as fs.MakeDirectoryOptions
-    mode = makeDirectoryOptions.mode || 0o777
+    if (typeof makeDirectoryOptions.mode === "number") {
+      mode = makeDirectoryOptions.mode || 0o777
+    } else {
+      mode = parseInt(makeDirectoryOptions.mode!, 8) || 0o777
+    }
     recursive = makeDirectoryOptions.recursive || false
   }
   if (recursive) {


### PR DESCRIPTION
New @types/node breaks mock class for `mode` parameter. It might be now string too then needs extra `parseInt`.